### PR TITLE
docs: Remove incorrect MCP expansion in Deploy and Run page

### DIFF
--- a/docs/agents/running.md
+++ b/docs/agents/running.md
@@ -46,7 +46,7 @@ The `--quiet` flag switches off the Progress, Chat and Tool displays.
 
 ## MCP Server Deployment
 
-Any **fast-agent** application can be deployed as an MCP (Message Control Protocol) server with a simple command-line switch.
+Any **fast-agent** application can be deployed as an MCP server with a simple command-line switch.
 
 ### Starting an MCP Server
 


### PR DESCRIPTION
The "MCP Server Deployment" section of the `running.md` documentation incorrectly expands the MCP acronym as "Message Control Protocol".

This commit removes the parenthetical expansion entirely. The rest of the page seems all good.

![image](https://github.com/user-attachments/assets/f3f583f2-2126-46e4-bc0a-91486df38263)

