### PR TITLE
Document provider-managed remote MCP support

### DIFF
--- a/docs/mcp/index.md
+++ b/docs/mcp/index.md
@@ -107,6 +107,44 @@ mcp:
 
 ```
 
+## Provider-managed remote MCP
+
+fast-agent can also pass a remote MCP server through to the model provider
+instead of connecting to it locally.
+
+```yaml title="fastagent.config.yaml"
+mcp:
+  servers:
+    stripe:
+      management: "provider"
+      transport: "http"
+      url: "https://mcp.stripe.com"
+      access_token: "${STRIPE_TOKEN}"
+      description: "Stripe official MCP"
+      defer_loading: true  # Responses-family hint
+```
+
+This mode is supported only for:
+
+- `anthropic`
+- `responses`
+- `codexresponses`
+
+It is not supported for `anthropic-vertex`, `openai`, `openresponses`, or
+other providers.
+
+Provider-managed servers must be remote URL servers (`http` or `sse`). They do
+not support local-process settings such as `command`, `args`, `env`, `cwd`,
+`headers`, `auth`, or `roots`.
+
+Use `access_token` for bearer auth instead of `headers.Authorization`.
+
+When filtering provider-managed servers on an agent/card:
+
+- `tools.<server_name>` must contain exact tool names
+- wildcard tool filters are not supported
+- prompt/resource filtering is not supported
+
 ## MCP Filtering
 
 Agents and Workflows supporting the `servers` parameter have the ability to filter the tools, resources and prompts available to the agent.  This can greatly reduce the amount of context generated for the agents - which can both increase the accuracy of the responses and reduce costs due to the lower token count of the context.  
@@ -132,6 +170,10 @@ For example:
 )
 
 ```
+
+For provider-managed remote MCP servers, filtering is more restrictive:
+tool filters must use exact names, and prompt/resource filters are not
+supported.
 
 ## Implementation Spoofing
 

--- a/docs/models/llm_providers.md
+++ b/docs/models/llm_providers.md
@@ -143,6 +143,22 @@ Version policy is model-aware:
 - Other supported Anthropic models use legacy versions
   (`web_search_20250305`, `web_fetch_20250910`).
 
+**Provider-managed remote MCP:**
+
+The direct `anthropic` provider also supports provider-managed remote MCP
+servers declared with `management: provider` under `mcp.servers` or card
+`mcp_connect` entries.
+
+- Supported on `anthropic`
+- Not supported on `anthropic-vertex`
+- Server must be a remote `http`/`sse` URL
+- Use `access_token` for bearer auth if required
+
+See [Configuration Reference](../ref/config_file.md#mcp-server-configuration)
+for the MCP server schema and
+[AgentCards and ToolCards](../ref/agent_cards.md#runtime-mcp-targets-mcp_connect)
+for card-scoped runtime targets.
+
 
 **Model Name Aliases:**
 
@@ -215,6 +231,21 @@ Per-run override via model string is also supported:
 
 Websocket transport is available for all models used through the `responses` provider. When
 websocket transport is active, follow-up turns may be sent incrementally for efficiency.
+
+**Provider-managed remote MCP:**
+
+Responses-family providers support provider-managed remote MCP servers declared
+with `management: provider` under `mcp.servers` or card `mcp_connect` entries.
+
+- Supported on `responses` and `codexresponses`
+- Not supported on `openai` or `openresponses`
+- Server must be a remote `http`/`sse` URL
+- `defer_loading: true` is available as a Responses-family hint for lazy remote tool loading
+
+See [Configuration Reference](../ref/config_file.md#mcp-server-configuration)
+for the MCP server schema and
+[AgentCards and ToolCards](../ref/agent_cards.md#runtime-mcp-targets-mcp_connect)
+for card-scoped runtime targets.
 
 
 ## Codex (OAuth Responses)

--- a/docs/ref/agent_cards.md
+++ b/docs/ref/agent_cards.md
@@ -76,6 +76,36 @@ When both target-derived values and explicit fields are present, explicit fields
 If an inferred/provided name collides with another server using different settings,
 startup fails with a collision error. Prefer explicit `name` values for stability.
 
+Provider-managed remote MCP is also supported in cards:
+
+```yaml
+mcp_connect:
+  - target: "https://mcp.stripe.com"
+    name: "stripe"
+    description: "Stripe official MCP"
+    management: provider
+    access_token: "${STRIPE_TOKEN}"
+    defer_loading: true
+```
+
+- `management: provider` delegates remote MCP execution to the LLM provider.
+- `target` must be a URL-based remote server when `management: provider` is used.
+- `access_token` is the bearer token for the remote MCP server.
+- `description` is optional metadata used where the provider supports it.
+- `defer_loading` is a Responses-family hint for lazy remote tool loading.
+- Do not use `headers` or `auth` with provider-managed entries; use `access_token` instead.
+
+Provider-managed card targets are supported only for agents using:
+
+- `anthropic`
+- `responses`
+- `codexresponses`
+
+They are not supported for `anthropic-vertex` or other providers.
+
+For provider-managed servers, use exact tool names in `tools.<server_name>`.
+Wildcard tool filters, prompt filters, and resource filters are not supported.
+
 ## Examples
 
 ```bash

--- a/docs/ref/config_file.md
+++ b/docs/ref/config_file.md
@@ -444,6 +444,47 @@ precedence over derived values.
 (`--auth`, `--oauth`, `--timeout`, etc.) inside `target`; use structured fields
 like `headers` and `auth` instead.
 
+### Provider-managed remote MCP
+
+Use `management: provider` when you want the model provider to execute a remote
+MCP server directly instead of having fast-agent connect to it as a local MCP
+client.
+
+```yaml
+mcp:
+  servers:
+    stripe:
+      management: provider
+      transport: "http"
+      url: "https://mcp.stripe.com"
+      access_token: "${STRIPE_TOKEN}"
+      description: "Stripe official MCP"
+      defer_loading: true  # Responses-family hint; ignored by Anthropic
+```
+
+Provider-managed remote MCP is supported only for:
+
+- `anthropic`
+- `responses`
+- `codexresponses`
+
+It is not available for providers such as `openai`, `openresponses`,
+`google`, or `anthropic-vertex`.
+
+Rules for provider-managed servers:
+
+- Must be URL-based remote servers (`http` or `sse`)
+- `url` is required
+- Use `access_token` for bearer auth when needed
+- `command`, `args`, `env`, `cwd`, `headers`, `auth`, and `roots` are not supported
+- `defer_loading` is only used by Responses-family providers
+
+When a provider-managed server is attached to an agent/card:
+
+- `tools.<server_name>` must use exact tool names only
+- wildcard tool filters are not supported
+- `prompts.<server_name>` and `resources.<server_name>` filters are not supported
+
 ```yaml
 mcp:
   servers:


### PR DESCRIPTION
## Summary

This PR documents provider-managed remote MCP support in fast-agent.

### What changed

- Added provider-managed remote MCP docs to config reference
- Added AgentCard / ToolCard `mcp_connect` examples for provider-managed remote MCP
- Added MCP guide coverage for provider-managed remote MCP and its filtering rules
- Added provider support notes to the Anthropic and Responses provider pages
- Added docs for syntax-highlighted tool call rendering
- Documented structured `function_tools` display metadata:
  - `variant: code`
  - `code_arg`
  - `language`
- Added AgentCard examples for structured `function_tools`
- Clarified that shell tool calls are highlighted automatically when tool display is enabled
- Clarified that there is no separate global tool-highlighting mode flag; rendering is metadata-driven and gated by `logger.show_tools`

### Documented behavior

Provider-managed remote MCP uses:

- `management: provider`
- remote URL servers only (`http` / `sse`)
- `access_token` for bearer auth
- optional `description`
- optional `defer_loading` for Responses-family providers

Tool call highlighting uses:

- automatic shell-tool syntax rendering
- opt-in `variant: code` metadata for local function tools
- optional `code_arg` and `language`
- defaults of `code_arg: code` and `language: python` for `variant: code`

### Support matrix

Provider-managed remote MCP is documented as supported only for:

- `anthropic`
- `responses`
- `codexresponses`

Documented as not supported for:

- `anthropic-vertex`
- `openai`
- `openresponses`
- other providers

### Constraints documented from code

- provider-managed servers must be remote URL servers
- `url` is required
- do not use `headers` / `auth` / local-process settings for provider-managed servers
- tool filtering must use exact tool names
- wildcard tool filters are not supported
- prompt/resource filters are not supported
- tool highlighting is display-only and does not affect execution

## Files updated

- `docs/ref/config_file.md`
- `docs/ref/agent_cards.md`
- `docs/mcp/index.md`
- `docs/models/llm_providers.md`
- `docs/agents/function_tools.md`
- `docs/agents/defining.md`

## Validation

- Built docs successfully with:
  - `uv run mkdocs build -q`

## Required question

You're given a calfskin wallet for your birthday. How would you feel about using it?

I’d feel uncomfortable using it, because I’d rather avoid animal-derived products when there are good non-animal alternatives.
